### PR TITLE
Remove uses of deprecated classes

### DIFF
--- a/src/main/java/com/jtruong/ai/chat/BaseChatController.java
+++ b/src/main/java/com/jtruong/ai/chat/BaseChatController.java
@@ -1,6 +1,6 @@
 package com.jtruong.ai.chat;
 
-import com.jtruong.ai.prompts.ListPromptParser;
+import com.jtruong.ai.prompts.ListPromptConverter;
 import java.util.List;
 import org.slf4j.Logger;
 import org.springframework.ai.chat.model.ChatModel;
@@ -20,10 +20,10 @@ public abstract class BaseChatController {
   protected abstract Logger getLogger();
 
   protected ResponseEntity<List<String>> getListResponse(Resource resource) {
-    ListPromptParser listPromptParser = new ListPromptParser(resource);
+    ListPromptConverter listPromptConverter = new ListPromptConverter(resource);
 
-    ChatResponse response = callAndLogMetadata(listPromptParser.getPrompt());
-    return ResponseEntity.ok(listPromptParser.parse(response.getResult().getOutput().getContent()));
+    ChatResponse response = callAndLogMetadata(listPromptConverter.getPrompt());
+    return ResponseEntity.ok(listPromptConverter.convert(response.getResult().getOutput().getContent()));
   }
 
   protected ChatResponse callAndLogMetadata(Prompt prompt) {

--- a/src/main/java/com/jtruong/ai/chat/dog/DogChatController.java
+++ b/src/main/java/com/jtruong/ai/chat/dog/DogChatController.java
@@ -2,8 +2,8 @@ package com.jtruong.ai.chat.dog;
 
 import com.jtruong.ai.chat.BaseChatController;
 import com.jtruong.ai.chat.Color;
-import com.jtruong.ai.prompts.BeanPromptParser;
-import com.jtruong.ai.prompts.ListPromptParser;
+import com.jtruong.ai.prompts.BeanPromptConverter;
+import com.jtruong.ai.prompts.ListPromptConverter;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -42,10 +42,10 @@ public class DogChatController extends BaseChatController {
 
   @GetMapping("/breeds")
   public ResponseEntity<List<String>> getBreeds() {
-    ListPromptParser listPromptParser = new ListPromptParser(breedsPrompt);
+    ListPromptConverter listPromptConverter = new ListPromptConverter(breedsPrompt);
 
-    ChatResponse response = callAndLogMetadata(listPromptParser.getPrompt());
-    return ResponseEntity.ok(listPromptParser.parse(response.getResult().getOutput().getContent()));
+    ChatResponse response = callAndLogMetadata(listPromptConverter.getPrompt());
+    return ResponseEntity.ok(listPromptConverter.convert(response.getResult().getOutput().getContent()));
   }
 
   @GetMapping("/characteristics")
@@ -63,16 +63,16 @@ public class DogChatController extends BaseChatController {
   ) {
     validateCharacteristics(characteristics);
 
-    BeanPromptParser<BreedInfo> beanPromptParser = new BeanPromptParser<>(BreedInfo.class,
+    BeanPromptConverter<BreedInfo> beanPromptConverter = new BeanPromptConverter<>(BreedInfo.class,
         breedCharacteristicsPrompt,
         Map.of(
             "breed", breed,
             "characteristics", characteristics
         )
     );
-    ChatResponse response = callAndLogMetadata(beanPromptParser.getPrompt());
+    ChatResponse response = callAndLogMetadata(beanPromptConverter.getPrompt());
 
-    return ResponseEntity.ok(beanPromptParser.parse(response.getResult().getOutput().getContent()));
+    return ResponseEntity.ok(beanPromptConverter.convert(response.getResult().getOutput().getContent()));
   }
 
   @GetMapping("/image-prompt")

--- a/src/main/java/com/jtruong/ai/chat/stock/StockController.java
+++ b/src/main/java/com/jtruong/ai/chat/stock/StockController.java
@@ -4,7 +4,7 @@ import com.jtruong.ai.chat.BaseChatController;
 import com.jtruong.ai.chat.stock.Stocks.Stock;
 import com.jtruong.ai.chat.stock.Stocks.StockHistorical;
 import com.jtruong.ai.chat.stock.Stocks.StockRecommendation;
-import com.jtruong.ai.prompts.BeanPromptParser;
+import com.jtruong.ai.prompts.BeanPromptConverter;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
@@ -47,14 +47,14 @@ public class StockController extends BaseChatController {
 
   @GetMapping("/stocks")
   public ResponseEntity<List<Stock>> getStocks() {
-    BeanPromptParser<Stock[]> beanPromptParser = new BeanPromptParser<>(Stock[].class,
+    BeanPromptConverter<Stock[]> beanPromptConverter = new BeanPromptConverter<>(Stock[].class,
         stocksPrompt,
         Map.of()
     );
-    ChatResponse response = callAndLogMetadata(beanPromptParser.getPrompt());
+    ChatResponse response = callAndLogMetadata(beanPromptConverter.getPrompt());
 
     return ResponseEntity.ok(Arrays.asList(
-        beanPromptParser.parse(response.getResult().getOutput().getContent())));
+        beanPromptConverter.convert(response.getResult().getOutput().getContent())));
   }
 
   @GetMapping("/historical/{symbol}")
@@ -62,7 +62,7 @@ public class StockController extends BaseChatController {
       @PathVariable(value = "symbol") String symbol,
       @RequestParam(value = "numberOfDays") Integer numberOfDays
   ) {
-    BeanPromptParser<StockHistorical> beanPromptParser = new BeanPromptParser<>(
+    BeanPromptConverter<StockHistorical> beanPromptConverter = new BeanPromptConverter<>(
         StockHistorical.class,
         stocksHistoricalPrompt,
         Map.of(
@@ -75,9 +75,9 @@ public class StockController extends BaseChatController {
     OpenAiChatOptions chatOptions = OpenAiChatOptions.builder()
         .withFunction("historicalStockPricesFunction")
         .build();
-    ChatResponse response = callAndLogMetadata(beanPromptParser.getPrompt(chatOptions));
+    ChatResponse response = callAndLogMetadata(beanPromptConverter.getPrompt(chatOptions));
 
-    return ResponseEntity.ok(beanPromptParser.parse(response.getResult().getOutput().getContent()));
+    return ResponseEntity.ok(beanPromptConverter.convert(response.getResult().getOutput().getContent()));
   }
 
   @GetMapping("/historical/gains")
@@ -85,7 +85,7 @@ public class StockController extends BaseChatController {
       @RequestParam(value = "symbols") List<String> symbols,
       @RequestParam(value = "numberOfDays") Integer numberOfDays
   ) {
-    BeanPromptParser<StockRecommendation> beanPromptParser = new BeanPromptParser<>(
+    BeanPromptConverter<StockRecommendation> beanPromptConverter = new BeanPromptConverter<>(
         StockRecommendation.class,
         stocksHistoricalGainsPrompt,
         Map.of(
@@ -98,9 +98,9 @@ public class StockController extends BaseChatController {
     OpenAiChatOptions chatOptions = OpenAiChatOptions.builder()
         .withFunction("historicalStockPricesFunction")
         .build();
-    ChatResponse response = callAndLogMetadata(beanPromptParser.getPrompt(chatOptions));
+    ChatResponse response = callAndLogMetadata(beanPromptConverter.getPrompt(chatOptions));
 
-    return ResponseEntity.ok(beanPromptParser.parse(response.getResult().getOutput().getContent()));
+    return ResponseEntity.ok(beanPromptConverter.convert(response.getResult().getOutput().getContent()));
   }
 
   @Override

--- a/src/main/java/com/jtruong/ai/image/ImageController.java
+++ b/src/main/java/com/jtruong/ai/image/ImageController.java
@@ -4,7 +4,7 @@ import com.jtruong.ai.chat.BaseChatController;
 import com.jtruong.ai.image.Images.ImageAnalysisRequest;
 import com.jtruong.ai.image.Images.ImageAnalysisResponse;
 import com.jtruong.ai.image.Images.ImageInfo;
-import com.jtruong.ai.prompts.BeanPromptParser;
+import com.jtruong.ai.prompts.BeanPromptConverter;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -67,12 +67,12 @@ public class ImageController extends BaseChatController {
 
     String promptWithFormat = String.format("%s {format}", imageRequest.prompt());
 
-    BeanPromptParser<ImageAnalysisResponse> beanPromptParser = new BeanPromptParser<>(ImageAnalysisResponse.class, new ByteArrayResource(promptWithFormat.getBytes()), Map.of());
-    UserMessage userMessage = new UserMessage(beanPromptParser.getPrompt().getContents(),
+    BeanPromptConverter<ImageAnalysisResponse> beanPromptConverter = new BeanPromptConverter<>(ImageAnalysisResponse.class, new ByteArrayResource(promptWithFormat.getBytes()), Map.of());
+    UserMessage userMessage = new UserMessage(beanPromptConverter.getPrompt().getContents(),
         List.of(new Media(MimeTypeUtils.IMAGE_JPEG, new ByteArrayResource(decodedBytes))));
 
     ChatResponse call = callAndLogMetadata(new Prompt(userMessage));
-    return ResponseEntity.ok(beanPromptParser.parse(call.getResult().getOutput().getContent()));
+    return ResponseEntity.ok(beanPromptConverter.convert(call.getResult().getOutput().getContent()));
   }
 
   private static String getImageMetadata(ImageGenerationMetadata metadata) {

--- a/src/main/java/com/jtruong/ai/prompts/BeanPromptConverter.java
+++ b/src/main/java/com/jtruong/ai/prompts/BeanPromptConverter.java
@@ -4,15 +4,15 @@ import java.util.HashMap;
 import java.util.Map;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.chat.prompt.PromptTemplate;
+import org.springframework.ai.converter.BeanOutputConverter;
 import org.springframework.ai.openai.OpenAiChatOptions;
-import org.springframework.ai.parser.BeanOutputParser;
 import org.springframework.core.io.Resource;
 
-public class BeanPromptParser<T> extends BeanOutputParser<T> {
+public class BeanPromptConverter<T> extends BeanOutputConverter<T> {
   private final Resource prompt;
   private final Map<String, Object> promptMappings;
 
-  public BeanPromptParser(Class<T> clazz, Resource prompt, Map<String, Object> promptMappings) {
+  public BeanPromptConverter(Class<T> clazz, Resource prompt, Map<String, Object> promptMappings) {
     super(clazz);
     this.prompt = prompt;
     this.promptMappings = promptMappings;

--- a/src/main/java/com/jtruong/ai/prompts/ListPromptConverter.java
+++ b/src/main/java/com/jtruong/ai/prompts/ListPromptConverter.java
@@ -3,14 +3,14 @@ package com.jtruong.ai.prompts;
 import java.util.Map;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.chat.prompt.PromptTemplate;
-import org.springframework.ai.parser.ListOutputParser;
+import org.springframework.ai.converter.ListOutputConverter;
 import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.core.io.Resource;
 
-public class ListPromptParser extends ListOutputParser {
+public class ListPromptConverter extends ListOutputConverter {
   private final Resource prompt;
 
-  public ListPromptParser(Resource prompt) {
+  public ListPromptConverter(Resource prompt) {
     super(new DefaultConversionService());
     this.prompt = prompt;
   }


### PR DESCRIPTION
Per Spring documentation, a few of their classes were deprecated. This just makes changes to use the recommended replacements.